### PR TITLE
More robust parsing of malformed SSH keys

### DIFF
--- a/django_sshkey/tests.py
+++ b/django_sshkey/tests.py
@@ -353,6 +353,22 @@ class UserKeyCreationTestCase(BaseTestCase):
     )
     self.assertRaises(ValidationError, key.full_clean)
 
+  def test_malformed_key_fails(self):
+    key = UserKey(
+      user=self.user1,
+      name='name1',
+      key='foo bar baz',
+    )
+    self.assertRaises(ValidationError, key.full_clean)
+
+  def test_malformed_key2_fails(self):
+    key = UserKey(
+      user=self.user1,
+      name='name1',
+      key='2048 01:02:03:04:05:06:07:08:09:10:11:12:13:14:15:16',
+    )
+    self.assertRaises(ValidationError, key.full_clean)
+
 
 class RFC4716TestCase(BaseTestCase):
   @classmethod

--- a/django_sshkey/util.py
+++ b/django_sshkey/util.py
@@ -92,7 +92,10 @@ class PublicKey(object):
       dlen = struct.unpack('>I', keydata[:4])[0]
       data, keydata = keydata[4:4 + dlen], keydata[4 + dlen:]
       self.parts.append(data)
-    self.algorithm = self.parts[0].decode('ascii')
+    try:
+      self.algorithm = self.parts[0].decode('ascii')
+    except UnicodeDecodeError as e:
+      raise TypeError(str(e))
 
   def fingerprint(self, hash=None):
     import hashlib


### PR DESCRIPTION
The new testcase would fail with:

  File "/tmp/django-sshkey/django_sshkey/util.py", line 96, in __init__
    self.algorithm = self.parts[0].decode('ascii')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd3 in position 2: ordinal not in range(128)

Backport of https://github.com/zorun/django-simplesshkey/commit/2ee730c2069cf311c364260f1ca002ba831472e0